### PR TITLE
Move update and insert queries to PHP

### DIFF
--- a/php/add.php
+++ b/php/add.php
@@ -1,0 +1,13 @@
+<?php
+include '../../../../apis/cartodbProxy.php';
+//			^CHANGE THIS TO THE PATH TO YOUR cartodbProxy.php
+$q = "INSERT INTO " . $_POST['table'] . " (the_geom, city, description, name,city_yrs,nbrhd_yrs,flag,loved) VALUES (ST_SetSRID(ST_GeomFromGeoJSON('";
+if ( $_POST['ext'] != "_point" ){
+  $q .= '{"type":"MultiPolygon","coordinates":[[[' . $_POST['coords'] . "]]]}'";
+} else {
+  $q .= '{"type":"Point","coordinates":' . $_POST['coords'] . "}'";
+}
+$q .= "),4326),'". $_POST['city'] ."','" . $_POST['description'] . "','" . $_POST['name'] . "','" . $_POST['cityYears'] . "','" . $_POST['hoodYears'] . "','false','0')";
+$return = goProxy($q);
+echo $return;
+?>

--- a/php/callProxy.php
+++ b/php/callProxy.php
@@ -1,7 +1,0 @@
-<?php
-include '../../../../apis/cartodbProxy.php';
-//			^CHANGE THIS TO THE PATH TO YOUR cartodbProxy.php
-$queryURL = $_POST['qurl'];
-$return = goProxy($queryURL);
-echo $return;
-?>

--- a/php/flag.php
+++ b/php/flag.php
@@ -1,0 +1,7 @@
+<?php
+include '../../../../apis/cartodbProxy.php';
+//      ^CHANGE THIS TO THE PATH TO YOUR cartodbProxy.php
+$q = "update " .$_POST['table'] . " set flag = true where cartodb_id = " . $_POST['id'];
+$return = goProxy($q);
+echo $return;
+?>

--- a/php/heart.php
+++ b/php/heart.php
@@ -1,0 +1,7 @@
+<?php
+include '../../../../apis/cartodbProxy.php';
+//      ^CHANGE THIS TO THE PATH TO YOUR cartodbProxy.php
+$q = "update " .$_POST['table'] . " set loved = loved " .$_POST['op'] . " where cartodb_id = " . $_POST['id'];
+$return = goProxy($q);
+echo $return;
+?>


### PR DESCRIPTION
It was pointed out to me that someone could post any ol' query to callProxy.php — including queries that delete things or otherwise wreak havoc. Not that my version is 100% secure, but this removes those update and insert queries into specific PHP scripts so that they're more hidden and so that it's not possible to send arbitrary editing queries. (Assuming CartoDB requires the API key for things like update and insert...)
