### PR TITLE
replace file_get_contents with curl function

### DIFF
--- a/php/cartodbProxy.php
+++ b/php/cartodbProxy.php
@@ -1,6 +1,23 @@
 <?php
 session_cache_limiter('nocache');
 $cache_limiter = session_cache_limiter();
+
+function url_get_contents ($inputURL) {
+    if (!function_exists('curl_init')){ 
+        exit('Sorry, CURL is not installed on your server.');
+    }
+    $ch = curl_init();
+
+    $options = array(CURLOPT_URL => $inputURL,
+                 CURLOPT_RETURNTRANSFER => true
+                );
+
+    curl_setopt_array($ch, $options);
+    $output = curl_exec($ch);
+    curl_close($ch);
+    return $output;
+}
+
 function goProxy($dataURL) 
 {
 	$baseURL = 'http://CARTODB-USER-NAME.cartodb.com/api/v2/sql?';
@@ -8,7 +25,7 @@ function goProxy($dataURL)
 	$api = '&api_key=';
 	//				 ^ENTER YOUR API KEY HERE!
 	$url = $baseURL.'q='.urlencode($dataURL).$api;
-	$result = file_get_contents ($url);
+	$result = url_get_contents ($url);
 	return $result;
 }
 ?>


### PR DESCRIPTION
This replaces file_get_contents that processes the data to cartodb.com with a curl function

Before this commit, you must enable [allow_url_fopen](http://php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen) in your php configuration (php.ini) in order to run neighborhoods. 

Allow_url_fopen is disabled on some shared web hosts, like mine (pair.com) because when it's enabled, the file_get_contents function can obtain data from remote places which is [insecure](http://phpsec.org/projects/phpsecinfo/tests/allow_url_fopen.html). 
It's recommend to use [curl instead](https://wiki.gandi.net/en/simple/php). 

I tested it on my instance and it works, although I cannot vouch for the quality of the code.
